### PR TITLE
feat(merge-bot): support commit message customization

### DIFF
--- a/packages/merge-bot/src/main.ts
+++ b/packages/merge-bot/src/main.ts
@@ -76,6 +76,7 @@ async function attemptMerge(): Promise<void> {
       commit_title: `${
         (context.payload as IssueCommentEditedEvent).issue.title
       } (#${(context.payload as IssueCommentEditedEvent).issue.number})`,
+      commit_message: process.env.COMMIT_MESSAGE,
       merge_method: "squash",
     });
   } catch (error) {


### PR DESCRIPTION
Allow customization of the commit message made by the bot.

This will allow its users to customize the commit message (i.e. not the title but the body/description) while keeping a semantic title.

This will allow @coveo/search for example to put the JIRA URL in it.

----

[CDX-590](https://coveord.atlassian.net/browse/CDX-590)